### PR TITLE
handle edge case of log_type "reviewed"

### DIFF
--- a/snitch.py
+++ b/snitch.py
@@ -423,7 +423,9 @@ class ReportBot(BotClient):
         if data['type'] == 'log':
             diff.update({
                 'log': data['log_type'],
-                'summary': data['log_action_comment']
+                'summary': (data['log_action_comment']
+                            if data['log_action_comment'] != 'reviewed'
+                            else 'pagetriage-curation')
             })
         else:
             diff.update({


### PR DESCRIPTION
For some reason EventStreams treats the `log_type` for a pagetriage curation as `reviewed` even though that isn't a valid `log_type`. Going to assume for now that this is a special case, rather than a broader issue, and handle as such.