### PR TITLE
Add global wiki type for all wikis

### DIFF
--- a/snitch.py
+++ b/snitch.py
@@ -442,7 +442,7 @@ class ReportBot(BotClient):
         # Begin rule matching
         ignore = set()
         for rule in rule_list:
-            if rule.wiki != wiki and rule.wiki != 'global':
+            if rule.wiki not in (wiki, 'global'):
                 continue
             if rule.channel in ignore:
                 continue

--- a/snitch.py
+++ b/snitch.py
@@ -442,7 +442,7 @@ class ReportBot(BotClient):
         # Begin rule matching
         ignore = set()
         for rule in rule_list:
-            if rule.wiki != wiki:
+            if rule.wiki != wiki and rule.wiki != 'global':
                 continue
             if rule.channel in ignore:
                 continue
@@ -485,7 +485,7 @@ class ReportBot(BotClient):
             ignore.add(rule.channel)
             # If the rule is not an ignore rule, relay the event
             if not rule.ignore:
-                await self.relay_message(rule.channel, rule.wiki, diff)
+                await self.relay_message(rule.channel, wiki, diff)
 
     async def message(self, target, message):
         """ Message channel or user.


### PR DESCRIPTION
Rules support a wiki type of `global` which will match all wikis. Most useful for log or user based rules.

A styling change may be wanted and in that case should be committed to the branch before the pull request is accepted. For example, global could be capitalized to stand out from other entries or global could be made case insensitive to allow user defined capitalization of it.