### PR TITLE
group regex rule before modification

### DIFF
--- a/snitch.py
+++ b/snitch.py
@@ -317,13 +317,7 @@ class ReportBot(BotClient):
                 try:
                     result = await self.whois(split_message[1])
                 except AttributeError:
-                    # pylint: disable-next=pointless-string-statement
-                    '''
-                    try:
-                        result = await self.whowas(split_message[1])
-                    except AttributeError:
-                        result = None
-                    '''
+                    pass
                 if not result:
                     await self.message(conversation, 'User not found')
                     return


### PR DESCRIPTION
Prevents a bug causing rules to behave unexpectedly if not first grouped by the user.

For example, the rule `test1|test2` would be expected to match only strings that are entirely equal to either `test1` or `test2` but would instead match any string that starts with `test1` or ends with `test2` because the rule would be converted to the regex `^test1|test2$`

An alternative suggested by Tamzin is to remove the rule modification and use fullmatch() instead of search()